### PR TITLE
[fix] Added NODE_ENV to docker-compose.yml for node

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,7 @@ services:
         context: ./node
         args:
           - NODE_VERSION=${NODE_VERSION}
+          - NODE_ENV=${NODE_ENV}
           - YARN_VERSION=${NODE_YARN_VERSION}
           - INSTALL_YARN=${NODE_INSTALL_YARN}
           - INSTALL_PG_CLIENT=${NODE_PG_CLIENT}


### PR DESCRIPTION
Even if you set in .env of nodedock
```ini
# This will be propagated to both node and workspace containers
NODE_ENV=production
```
it isn't going to be passed to node the container.
Updated `docker-compose.yml`, added NODE_ENV to NodeJS service

##### I completed the 2 steps below:

- [x] I've read the [Contribution Guide](http://nodedock.io/#/?id=contributing).
- [ ] I've updated the **documentation**. (refer to [README.md](../README.md) in a root directory for how to do so).
- [x] I enjoyed my time contributing and making developer's life easier :)
