### PR TITLE
Fix error: manifest for phusion/baseimage:latest not found: manifest …

### DIFF
--- a/beanstalkd/Dockerfile
+++ b/beanstalkd/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:latest
+FROM phusion/baseimage:bionic-1.0.0
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/certbot/Dockerfile
+++ b/certbot/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:latest
+FROM phusion/baseimage:bionic-1.0.0
 
 COPY run-certbot.sh /root/certbot/run-certbot.sh
 

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,6 +1,6 @@
 ARG NODE_VERSION=${NODE_VERSION}
 
-FROM phusion/baseimage:latest
+FROM phusion/baseimage:bionic-1.0.0
 
 # Set Environment Variables
 ENV DEBIAN_FRONTEND noninteractive

--- a/workspace/Dockerfile
+++ b/workspace/Dockerfile
@@ -1,6 +1,6 @@
 ARG NODE_VERSION=${NODE_VERSION}
 
-FROM phusion/baseimage:latest
+FROM phusion/baseimage:bionic-1.0.0
 
 # Set Environment Variables
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
## Issue
I cloned the master branch and run the command:
`docker-compose build workspace` 

It failed with the following error message

Building workspace
Step 1/81 : ARG NODE_VERSION=${NODE_VERSION}
Step 2/81 : FROM phusion/baseimage:latest
ERROR: Service 'workspace' failed to build: manifest for phusion/baseimage:latest not found: manifest unknown: manifest unknown

## Fix
Looks like the `latest` tag is no more available for phusion/baseimage docker image, so I just updated it to  `phusion/baseimage:bionic-1.0.0`